### PR TITLE
Alphabetize nodes and add configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.0.4] - 2023-05-26
+### Added
+- Alphabetized ZK nodes in explorer
+- Default language setting for nodes without extension
+- Default ZK host configured on startup
+
 ## [1.0.3] - 2022-03-19
 ### Fixed
 - command title in extensiton manage page

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Visually manage your ZooKeeper in Visual Studio Code.
 - `visualZooKeeper.zooKeeperServer`, default ``
 - `visualZooKeeper.nodeLanguage`, default `yaml`
 
-![settings](screenshots/settings.PNG)
-
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,41 @@ Visually manage your ZooKeeper in Visual Studio Code.
 
 ## Extension Settings
 
-When using Visual ZooKeeper for the first time, you need to configure the server address of zk, you can click the button or use the command palette to call out the configuration page.
+- `visualZooKeeper.zooKeeperServer`, default ``
+- `visualZooKeeper.nodeLanguage`, default `yaml`
 
-![config](screenshots/6-config.png)
+![settings](screenshots/settings.PNG)
 
 
-## Known Issues
+## Commands
+
+- `visualZooKeeper.editNode`
+- `visualZooKeeper.refreshNode`
+- `visualZooKeeper.configureServer`
+- `visualZooKeeper.addNode`
+- `visualZooKeeper.viewNodeStat`
+- `visualZooKeeper.copyPath`
+
+## Development
+
+Follow the vscode extension documentation: https://code.visualstudio.com/api/get-started/your-first-extension 
+
+- Install node.js and Git
+- `npm install -g yo generator-code`
+- `npm install -g yarn`
+- `yarn` to install the project dependencies
+- Use vsce to build the .vsix file for installation https://code.visualstudio.com/api/working-with-extensions/publishing-extension 
+    - `npm install -g @vscode/vsce`
+    - Build with `vsce package`
+
 
 ## Release Notes
+
+### 1.0.4
+
+- Alphabetized ZK nodes in explorer
+- Default language setting for nodes without extension
+- Default ZK host configured on startup
 
 ### 1.0.0
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,17 @@
 	"displayName": "Visual ZooKeeper",
 	"publisher": "gaoliang",
 	"description": "Visually manage your ZooKeeper in Visual Studio Code.",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"repository": "https://github.com/gaoliang/visual-zookeeper",
 	"license": "SEE LICENSE IN LICENSE",
 	"icon": "media/zk-logo.png",
-	"categories": ["Visualization", "Other"],
-	"keywords": ["zookeeper"],
+	"categories": [
+		"Visualization",
+		"Other"
+	],
+	"keywords": [
+		"zookeeper"
+	],
 	"engines": {
 		"vscode": "^1.65.0"
 	},
@@ -30,6 +35,20 @@
 					"icon": "media/zookeeper.svg"
 				}
 			]
+		},
+		"configuration": {
+			"title": "Visual ZooKeeper",
+			"properties": {
+				"visualZooKeeper.zooKeeperServer": {
+					"type": "string",
+					"description": "Comma separated host:port pairs, each represents a ZooKeeper server."
+				},
+				"visualZooKeeper.nodeLanguage": {
+					"type": "string",
+					"default": "plaintext",
+					"description": "Default language mode used to edit ZK nodes without an extension"
+				}
+			}
 		},
 		"commands": [
 			{
@@ -87,7 +106,7 @@
 				{
 					"command": "visualZooKeeper.copyPath",
 					"when": "view == visualZooKeeper && viewItem == zkNode"
-				  }
+				}
 			],
 			"view/title": [
 				{

--- a/src/ZkClient.ts
+++ b/src/ZkClient.ts
@@ -72,6 +72,7 @@ export const getChildren = (parent?: ZkNode): Promise<ZkNode[]> => {
                 if (error) {
                     reject(error);
                 }
+                children.sort();
                 resolve(children.map(child => {
                     return new ZkNode(
                         child, '',


### PR DESCRIPTION
- Alphabetize nodes in the explorer pane
- Add `zooKeeperServer` setting to allow configuration of default server
- Add `nodeLanguage` setting to allow setting node language if node names don't have extensions